### PR TITLE
Add internal link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Actitud Fitness
+
+Este proyecto incluye una serie de archivos HTML que hacen referencia entre sí. Para verificar que todos los enlaces internos funcionen correctamente puedes ejecutar:
+
+```bash
+npm test
+```
+
+El comando ejecutará un script que recorre los archivos `.html` y comprueba que los enlaces a archivos locales existan. En caso de encontrar enlaces rotos se mostrará un mensaje por consola y el proceso terminará con código de error.

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8"
+  },
+  "scripts": {
+    "test": "node scripts/check-links.js"
   }
 }

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+function getHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue; // skip node_modules
+      files = files.concat(getHtmlFiles(path.join(dir, entry.name)));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function checkLinks(file, repoRoot) {
+  const content = fs.readFileSync(file, 'utf8');
+  const linkRegex = /<a\s+[^>]*?href=["']([^"']+)["'][^>]*>/gi;
+  let match;
+  let errors = [];
+  while ((match = linkRegex.exec(content))) {
+    const href = match[1];
+    if (/^(#|https?:\/\/|mailto:|tel:|javascript:)/i.test(href)) {
+      continue;
+    }
+    let target = href.split('#')[0].split('?')[0];
+    if (!target) continue;
+    const targetPath = path.resolve(
+      path.isAbsolute(target) ? repoRoot : path.dirname(file),
+      target
+    );
+    if (!fs.existsSync(targetPath)) {
+      errors.push({ file, href });
+    }
+  }
+  return errors;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const htmlFiles = getHtmlFiles(repoRoot);
+  let broken = [];
+  for (const file of htmlFiles) {
+    broken = broken.concat(checkLinks(file, repoRoot));
+  }
+  if (broken.length > 0) {
+    console.error('Broken links found:');
+    for (const b of broken) {
+      console.error(`  ${b.file}: ${b.href}`);
+    }
+    console.error(`${broken.length} broken link(s) found.`);
+    process.exit(1);
+  } else {
+    console.log('All internal links are valid.');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add Node script to scan HTML files and report broken internal links
- expose the script via `npm test`
- document usage in a new README

## Testing
- `npm test` *(fails: broken links found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad4e006c832d9f2cf9be35231e3c